### PR TITLE
feat: add devServer client/devMiddleware

### DIFF
--- a/src/DevServer.js
+++ b/src/DevServer.js
@@ -58,6 +58,8 @@ module.exports = class extends ChainedMap {
       'watchContentBase',
       'watchOptions',
       'writeToDisk',
+      'client',
+      'devMiddleware',
     ]);
   }
 

--- a/test/DevServer.js
+++ b/test/DevServer.js
@@ -28,3 +28,29 @@ test('shorthand methods', () => {
 
   expect(devServer.entries()).toStrictEqual(obj);
 });
+
+test('set client', () => {
+  const devServer = new DevServer();
+  devServer.client({
+    progress: true,
+  });
+
+  expect(devServer.toConfig()).toStrictEqual({
+    client: {
+      progress: true,
+    },
+  });
+});
+
+test('set devMiddleware', () => {
+  const devServer = new DevServer();
+  devServer.devMiddleware({
+    publicPath: '/',
+  });
+
+  expect(devServer.toConfig()).toStrictEqual({
+    devMiddleware: {
+      publicPath: '/',
+    },
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -242,6 +242,36 @@ declare namespace Config {
     clean(value: WebpackOutput['clean']): this;
   }
 
+  type WebSocketURL = {
+    hostname?: string | undefined;
+    password?: string | undefined;
+    pathname?: string | undefined;
+    port?: string | number | undefined;
+    protocol?: string | undefined;
+    username?: string | undefined;
+  };
+  type ClientConfiguration = {
+    logging?:
+      | 'none'
+      | 'error'
+      | 'warn'
+      | 'info'
+      | 'log'
+      | 'verbose'
+      | undefined;
+    overlay?:
+      | boolean
+      | {
+          warnings?: boolean | undefined;
+          errors?: boolean | undefined;
+        }
+      | undefined;
+    progress?: boolean | undefined;
+    reconnect?: number | boolean | undefined;
+    webSocketTransport?: string | undefined;
+    webSocketURL?: string | WebSocketURL | undefined;
+  };
+
   // await for @types/webpack-dev-server update do v4 to remove all any
   class DevServer extends ChainedMap<Config> {
     allowedHosts: TypedChainedSet<this, string>;
@@ -321,6 +351,8 @@ declare namespace Config {
     watchContentBase(value: boolean): this;
     watchOptions(value: Configuration['watchOptions']): this;
     writeToDisk(value: boolean): this;
+    client(value: boolean | ClientConfiguration): this;
+    devMiddleware(value: any): this;
   }
 
   type WebpackPerformance = Exclude<

--- a/types/test/webpack-chain-tests.ts
+++ b/types/test/webpack-chain-tests.ts
@@ -295,6 +295,12 @@ config
     'Content-Type': 'text/css',
   })
   .historyApiFallback(true)
+  .client({
+    progress: true,
+  })
+  .devMiddleware({
+    publicPath: '/',
+  })
   .host('localhost')
   .hot(true)
   .hotOnly(true)


### PR DESCRIPTION
support devServer set client/devMiddleware

webpack configuration document
- [client](https://webpack.js.org/configuration/dev-server/#devserverclient)
- [devMiddleware](https://webpack.js.org/configuration/dev-server/#devserverdevmiddleware)