### PR TITLE
fix: support use resolve.merge api merge fallback & byDependency

### DIFF
--- a/src/Resolve.js
+++ b/src/Resolve.js
@@ -71,6 +71,8 @@ module.exports = class extends ChainedMap {
       'restrictions',
       'roots',
       'modules',
+      'fallback',
+      'byDependency',
     ];
 
     if (!omit.includes('plugin') && 'plugin' in obj) {

--- a/test/Resolve.js
+++ b/test/Resolve.js
@@ -99,6 +99,34 @@ test('merge with values', () => {
   });
 });
 
+test('merge omissions and omit', () => {
+  const resolve = new Resolve();
+
+  resolve.merge({
+    // should merge
+    alias: { ReactDOM: 'src/react-dom' },
+    // should merge
+    fallback: {
+      "child_process": false,
+      "cluster": false,
+    },
+    // should not merge
+    byDependency: {
+      esm: {
+        mainFields: ['browser', 'module'],
+      },
+    },
+  }, ['byDependency']);
+
+  expect(resolve.toConfig()).toStrictEqual({
+    alias: { ReactDOM: 'src/react-dom' },
+    fallback: {
+      "child_process": false,
+      "cluster": false,
+    },
+  });
+});
+
 test('merge with omit', () => {
   const resolve = new Resolve();
 


### PR DESCRIPTION
support use resolve.merge api merge fallback and byDependency.

```
  resolve.merge({
    fallback: {
      "child_process": false,
      "cluster": false,
    },
  });
```